### PR TITLE
feat(site): pivot to labs.yo-yodyne.com subdomain

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -3,8 +3,7 @@ import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  site: 'https://yo-yodyne.com',
-  base: '/labs',
+  site: 'https://labs.yo-yodyne.com',
   integrations: [mdx(), sitemap()],
   markdown: {
     shikiConfig: {

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -2,15 +2,15 @@
 import LogoMark from './LogoMark.astro';
 ---
 <nav>
-  <a href="/labs/" class="logo">
+  <a href="/" class="logo">
     <LogoMark size={22} />
     <span>Yo-Yodyne Labs</span>
   </a>
   <div class="links">
-    <a href="/labs/research/">Research</a>
-    <a href="/labs/experiments/">Experiments</a>
-    <a href="/labs/projects/">Projects</a>
-    <a href="/labs/about/">About</a>
+    <a href="/research/">Research</a>
+    <a href="/experiments/">Experiments</a>
+    <a href="/projects/">Projects</a>
+    <a href="/about/">About</a>
   </div>
 </nav>
 

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -17,7 +17,7 @@ const { title, description = 'Yo-Yodyne Labs — Research and creative productio
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content={description} />
   <title>{title} — Yo-Yodyne Labs</title>
-  <link rel="icon" type="image/svg+xml" href="/labs/favicon.svg" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 </head>
 <body>
   <div class="container">

--- a/site/src/pages/experiments/index.astro
+++ b/site/src/pages/experiments/index.astro
@@ -16,7 +16,7 @@ const experiments = (await getCollection('experiments'))
         {experiments.map((exp) => (
           <ContentCard
             title={exp.data.title}
-            href={`/labs/experiments/${exp.id}/`}
+            href={`/experiments/${exp.id}/`}
             date={exp.data.date}
             description={exp.data.hypothesis}
             tags={exp.data.tags}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -12,15 +12,15 @@ import LogoMark from '../components/LogoMark.astro';
   </section>
 
   <section class="sections">
-    <a href="/labs/research/" class="section-link">
+    <a href="/research/" class="section-link">
       <h2>Research</h2>
       <p class="muted">Explorations in science and engineering — accessible treatments alongside technical depth.</p>
     </a>
-    <a href="/labs/experiments/" class="section-link">
+    <a href="/experiments/" class="section-link">
       <h2>Experiments</h2>
       <p class="muted">Hypotheses tested, observations recorded, results analyzed.</p>
     </a>
-    <a href="/labs/projects/" class="section-link">
+    <a href="/projects/" class="section-link">
       <h2>Projects</h2>
       <p class="muted">Active and archived builds — software, tools, and creative works.</p>
     </a>

--- a/site/src/pages/projects/index.astro
+++ b/site/src/pages/projects/index.astro
@@ -19,7 +19,7 @@ const projects = (await getCollection('projects'))
             title={project.data.title}
             href={project.data.subdomain
               ? `https://${project.data.subdomain}.yo-yodyne.com`
-              : `/labs/projects/${project.id}/`}
+              : `/projects/${project.id}/`}
             date={project.data.date}
             description={project.data.tagline}
             tags={project.data.tags}

--- a/site/src/pages/research/index.astro
+++ b/site/src/pages/research/index.astro
@@ -17,7 +17,7 @@ const posts = (await getCollection('research'))
         {posts.map((post) => (
           <ContentCard
             title={post.data.title}
-            href={`/labs/research/${post.id}/`}
+            href={`/research/${post.id}/`}
             date={post.data.date}
             description={post.data.abstract}
             tags={post.data.tags}

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -7,14 +7,14 @@
   font-style: normal;
   font-weight: 300 700;
   font-display: swap;
-  src: url('/labs/fonts/cormorant-garamond-variable-latin.woff2') format('woff2');
+  src: url('/fonts/cormorant-garamond-variable-latin.woff2') format('woff2');
 }
 @font-face {
   font-family: 'Karla';
   font-style: normal;
   font-weight: 300 700;
   font-display: swap;
-  src: url('/labs/fonts/karla-variable-latin.woff2') format('woff2');
+  src: url('/fonts/karla-variable-latin.woff2') format('woff2');
 }
 
 /* --- Tokens --- */

--- a/site/worker/wrangler.toml
+++ b/site/worker/wrangler.toml
@@ -2,6 +2,6 @@ name = "yo-yodyne-labs-proxy"
 main = "labs-proxy.js"
 compatibility_date = "2026-03-08"
 
-# Route configuration — set up in Cloudflare dashboard:
-# Route pattern: yo-yodyne.com/labs/*
-# Zone: yo-yodyne.com
+routes = [
+  { pattern = "yo-yodyne.com/labs/*", zone_name = "yo-yodyne.com" }
+]


### PR DESCRIPTION
Remove /labs base path, update all internal links and asset URLs to serve from root. Configure Worker route and Cloudflare Pages custom domain for labs.yo-yodyne.com subdomain hosting.