### PR TITLE
docs: update specs and docs for labs.yo-yodyne.com subdomain architec…

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -21,7 +21,7 @@ Run agents in tmux sessions named after their role: `pi`, `research`, `engineeri
 ## Key Paths
 
 - `openspec/` — Specifications and change management
-- `site/` — Astro static site (yo-yodyne.com/labs)
+- `site/` — Astro static site (labs.yo-yodyne.com)
 - `research/` — Research artifacts
 - `engineering/` — Standards, agreements, templates
 - `production/` — Creative briefs, content staging, assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - Agent team definitions (PI, Researcher, Engineer, Technician, Writer, Creative Director)
 - Astro site scaffold with Content Collections (research, experiments, projects)
 - Wabi-sabi design tokens and base styles
-- Cloudflare Worker reverse proxy for yo-yodyne.com/labs
+- Cloudflare Pages deployment at labs.yo-yodyne.com
 - CI/CD: site deployment, release gating, spec lint
 - Dependency registry
 - Creative autonomy principle as core working agreement

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Yo-Yodyne
 
-Research hub and creative production orchestration for [yo-yodyne.com/labs](https://yo-yodyne.com/labs).
+Research hub and creative production orchestration for [labs.yo-yodyne.com](https://labs.yo-yodyne.com).
 
 ## Structure
 
 ```
 openspec/       Specifications and change management (OPSX workflow)
-site/           Astro static site → yo-yodyne.com/labs
+site/           Astro static site → labs.yo-yodyne.com
 research/       Research artifacts
 engineering/    Standards, working agreements, templates
 production/     Creative briefs, content staging, multimedia

--- a/engineering/guides/cloudflare-setup.md
+++ b/engineering/guides/cloudflare-setup.md
@@ -1,7 +1,8 @@
 # Cloudflare Setup Guide
 
 **Owner:** Engineering / Tech
-**Date:** 2026-03-09
+**Date:** 2026-03-12
+**Updated:** Pivoted from `/labs` subpath to `labs.yo-yodyne.com` subdomain
 
 ---
 
@@ -9,8 +10,7 @@
 
 - Cloudflare account with yo-yodyne.com domain
 - GitHub repo: github.com/neilsone/yo-yodyne
-- Wrangler CLI installed (`npm install -g wrangler`)
-- Cloudflare API token with Pages and Workers permissions
+- Cloudflare API token with Pages and DNS permissions
 
 ## Step 1: Create Cloudflare Pages Project
 
@@ -23,75 +23,34 @@
    - **Build output directory:** `site/dist`
 4. Deploy
 
-Or via CLI:
-
-```bash
-cd site
-wrangler pages project create yo-yodyne-labs
-npm run build
-wrangler pages deploy dist --project-name=yo-yodyne-labs
-```
-
 Verify: `https://yo-yodyne-labs.pages.dev` should show the labs site.
 
-## Step 2: Deploy Cloudflare Worker
+## Step 2: Configure Custom Domain
 
-```bash
-cd site/worker
-wrangler deploy
-```
-
-This deploys the reverse proxy worker defined in `labs-proxy.js` with config from `wrangler.toml`.
-
-## Step 3: Configure Worker Route
-
-1. Cloudflare Dashboard → Workers & Pages → yo-yodyne-labs-proxy
-2. Settings → Triggers → Add Route
-3. Route: `yo-yodyne.com/labs/*`
-4. Zone: `yo-yodyne.com`
-
-Or via Wrangler — add to `wrangler.toml`:
-
-```toml
-routes = [
-  { pattern = "yo-yodyne.com/labs/*", zone_name = "yo-yodyne.com" }
-]
-```
-
-Then redeploy: `wrangler deploy`
-
-## Step 4: Switch DNS to Proxied
-
-**IMPORTANT:** This step affects the main Adobe Portfolio site. Do this carefully.
-
-1. Cloudflare Dashboard → DNS
-2. Find the A records for `yo-yodyne.com` (pointing to Adobe Portfolio IPs)
-3. Change proxy status from **DNS only** (grey cloud) to **Proxied** (orange cloud)
-4. Set SSL/TLS mode to **Full (strict)**
+1. In the Pages project, add `labs.yo-yodyne.com` as a custom domain
+2. Add a CNAME DNS record:
+   - **Name:** `labs`
+   - **Target:** `yo-yodyne-labs.pages.dev`
+   - **Proxy status:** Proxied (orange cloud)
+3. Wait for SSL certificate to provision (usually a few minutes)
 
 ### Verification
 
-After switching:
 - `yo-yodyne.com` → Should still show Adobe Portfolio site
-- `yo-yodyne.com/labs/` → Should show the labs Astro site
+- `labs.yo-yodyne.com` → Should show the labs Astro site
 
-If Adobe Portfolio breaks:
-- Switch A records back to DNS only (grey cloud)
-- Investigate SSL/TLS settings
-- Adobe may need re-verification (unlikely if it was already working)
-
-## Step 5: GitHub Actions Secrets
+## Step 3: GitHub Actions Secrets
 
 Add these secrets to the GitHub repo (Settings → Secrets → Actions):
 
 | Secret | Value |
 |---|---|
-| `CLOUDFLARE_API_TOKEN` | API token with Pages:Edit and Workers:Edit |
+| `CLOUDFLARE_API_TOKEN` | API token with Pages:Edit permission |
 | `CLOUDFLARE_ACCOUNT_ID` | Your Cloudflare account ID |
 
 After this, pushes to `main` that change `site/` will auto-deploy.
 
-## Step 6: Project Subdomains (Future)
+## Step 4: Project Subdomains (Future)
 
 For each new project subdomain (e.g., `projectname.yo-yodyne.com`):
 
@@ -102,16 +61,11 @@ For each new project subdomain (e.g., `projectname.yo-yodyne.com`):
 
 ## Troubleshooting
 
-### Worker not intercepting /labs
+### Labs site not loading
 
-- Verify route is active: Dashboard → Workers → Routes
-- Check Worker logs: `wrangler tail yo-yodyne-labs-proxy`
-
-### Adobe Portfolio broken after proxying
-
-- Ensure SSL/TLS is set to Full (strict)
-- Check that A records still point to Adobe Portfolio IPs
-- Try toggling proxy off and on
+- Verify CNAME record exists: `labs` → `yo-yodyne-labs.pages.dev`
+- Check that proxy status is set to Proxied (orange cloud)
+- Verify custom domain is active in Pages project settings
 
 ### Pages deploy failing
 

--- a/openspec/changes/yo-yodyne-labs-init/design.md
+++ b/openspec/changes/yo-yodyne-labs-init/design.md
@@ -34,7 +34,7 @@ yo-yodyne/
 │   ├── changes/
 │   └── archive/
 │
-├── site/                               # Astro static site (yo-yodyne.com/labs)
+├── site/                               # Astro static site (labs.yo-yodyne.com)
 │   ├── astro.config.mjs
 │   ├── package.json
 │   ├── src/
@@ -203,37 +203,6 @@ const projects = defineCollection({
 }
 ```
 
-### Cloudflare Worker (`worker/labs-proxy.js`)
-
-```javascript
-export default {
-  async fetch(request) {
-    const url = new URL(request.url);
-
-    // Only intercept /labs paths
-    if (!url.pathname.startsWith('/labs')) {
-      return fetch(request);
-    }
-
-    // Rewrite to Cloudflare Pages origin
-    const labsUrl = new URL(url.pathname.replace(/^\/labs/, '') || '/',
-      'https://yo-yodyne-labs.pages.dev');
-    labsUrl.search = url.search;
-
-    const response = await fetch(labsUrl.toString(), {
-      headers: request.headers,
-      method: request.method,
-    });
-
-    // Return with original headers, add cache control
-    return new Response(response.body, {
-      status: response.status,
-      headers: response.headers,
-    });
-  }
-};
-```
-
 ### Astro Configuration (`astro.config.mjs`)
 
 ```javascript
@@ -242,8 +211,7 @@ import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  site: 'https://yo-yodyne.com',
-  base: '/labs',
+  site: 'https://labs.yo-yodyne.com',
   integrations: [mdx(), sitemap()],
   markdown: {
     shikiConfig: {
@@ -252,6 +220,9 @@ export default defineConfig({
   },
 });
 ```
+
+> **Note:** The Worker reverse proxy (`worker/labs-proxy.js`) is retained in the repo
+> but is no longer used. The site is served directly via Cloudflare Pages subdomain.
 
 ## Agent Team Configuration
 
@@ -280,9 +251,8 @@ PI dispatches work via creative briefs (Production-initiated) or proposals (OPSX
 
 ### Site Deployment (`deploy-site.yml`)
 1. **Trigger:** Push to `main` affecting `site/` directory
-2. **Build:** `npm run build` in `site/` (Astro build with `/labs` base)
+2. **Build:** `npm run build` in `site/`
 3. **Deploy:** Cloudflare Pages via `wrangler pages deploy`
-4. **Worker:** Deploy/update the labs proxy Worker
 
 ### Release Gating (`release-gate.yml`)
 1. **Trigger:** Tag matching `v*`
@@ -296,8 +266,7 @@ PI dispatches work via creative briefs (Production-initiated) or proposals (OPSX
 ## Cloudflare Setup Steps
 
 1. Deploy Astro site to Cloudflare Pages project `yo-yodyne-labs`
-2. Verify Adobe Portfolio custom domain is working at yo-yodyne.com
-3. In Cloudflare DNS, switch A records from DNS-only to Proxied
-4. Create Worker route: `yo-yodyne.com/labs/*` → labs-proxy Worker
-5. Test both Adobe Portfolio and /labs site
-6. For future projects: add CNAME records for subdomains → respective Pages projects
+2. Add CNAME record: `labs` → `yo-yodyne-labs.pages.dev` (proxied)
+3. Add `labs.yo-yodyne.com` as custom domain on Pages project
+4. Verify both Adobe Portfolio (yo-yodyne.com) and labs subdomain function correctly
+5. For future projects: add CNAME records for subdomains → respective Pages projects

--- a/openspec/changes/yo-yodyne-labs-init/proposal.md
+++ b/openspec/changes/yo-yodyne-labs-init/proposal.md
@@ -13,7 +13,7 @@ Neilson Eney is an independent researcher and 30-year software engineering veter
 
 The hub must:
 
-1. Provide a public-facing labs site at `yo-yodyne.com/labs` that embodies the brand
+1. Provide a public-facing labs site at `labs.yo-yodyne.com` that embodies the brand
 2. Establish an AI agent team that operates under loose, creatively autonomous working agreements
 3. Support the full lifecycle from research ideation through curated publication
 4. Enforce engineering rigor (specs, gating, release channels) without constraining creative autonomy
@@ -25,7 +25,7 @@ The hub must:
 1. **Organizational Structure** — Four loosely coupled units with creative autonomy
 2. **Agent Team** — Claude Code Teams for PI, researchers, engineers, technicians, writers, creative producers
 3. **Working Agreements** — Common + unit-specific standards; creative decisions owned by producing unit
-4. **Static Site** — Astro-based site at `yo-yodyne.com/labs` via Cloudflare Worker + Cloudflare Pages
+4. **Static Site** — Astro-based site at `labs.yo-yodyne.com` via Cloudflare Pages
 5. **CI/CD** — GitHub Actions for site deployment + release gating
 6. **OpenSpec Integration** — OPSX workflow as the standard for all changes
 7. **Release Process** — Alpha → Beta → Stable channels with Release Readiness Reviews
@@ -121,27 +121,26 @@ The **Tech unit** maintains a dependency registry (`engineering/dependencies/reg
 
 ## Hosting Architecture
 
-### Decision: `yo-yodyne.com/labs` via Cloudflare Worker Reverse Proxy
+### Decision: `labs.yo-yodyne.com` via Cloudflare Pages Subdomain
 
 ```
-yo-yodyne.com/*           → Adobe Portfolio (default)
-yo-yodyne.com/labs/*      → Cloudflare Worker → yo-yodyne-labs.pages.dev
+yo-yodyne.com             → Adobe Portfolio (photography/portfolio)
+labs.yo-yodyne.com        → Cloudflare Pages (yo-yodyne-labs.pages.dev)
 *.yo-yodyne.com           → Project subdomains (CNAME to respective hosts)
 ```
 
 **Setup sequence:**
 1. Deploy Astro site to Cloudflare Pages (`yo-yodyne-labs.pages.dev`)
-2. Ensure Adobe Portfolio domain is verified and working
-3. Switch Cloudflare A records from grey cloud (DNS-only) to orange cloud (proxied)
-4. Deploy Cloudflare Worker on route `yo-yodyne.com/labs/*`
-5. Verify both Adobe Portfolio root and `/labs` site function correctly
+2. Add CNAME record: `labs` → `yo-yodyne-labs.pages.dev` (proxied)
+3. Add `labs.yo-yodyne.com` as custom domain on Pages project
+4. Verify both Adobe Portfolio root and labs subdomain function correctly
 
-**URL structure under /labs:**
-- `yo-yodyne.com/labs/` — Labs homepage
-- `yo-yodyne.com/labs/research/` — Research articles and summaries
-- `yo-yodyne.com/labs/experiments/` — Experiment logs
-- `yo-yodyne.com/labs/projects/` — Project index
-- `yo-yodyne.com/labs/about/` — About the lab
+**URL structure:**
+- `labs.yo-yodyne.com/` — Labs homepage
+- `labs.yo-yodyne.com/research/` — Research articles and summaries
+- `labs.yo-yodyne.com/experiments/` — Experiment logs
+- `labs.yo-yodyne.com/projects/` — Project index
+- `labs.yo-yodyne.com/about/` — About the lab
 
 **Subdomain strategy for projects:**
 - `projectname.yo-yodyne.com` — Individual project sites

--- a/openspec/changes/yo-yodyne-labs-init/tasks.md
+++ b/openspec/changes/yo-yodyne-labs-init/tasks.md
@@ -63,7 +63,7 @@
 ## Phase 5: Astro Site
 
 - [x] Initialize Astro project in site/
-- [x] Configure astro.config.mjs with /labs base path
+- [x] Configure astro.config.mjs (subdomain: labs.yo-yodyne.com)
 - [x] Define Content Collections (research, experiments, projects)
 - [x] Create design tokens (wabi-sabi palette, typography)
 - [x] Build Base layout (nav, footer, brand shell)
@@ -75,11 +75,12 @@
 - [x] Self-host fonts (Cormorant Garamond, Karla — variable woff2)
 - [x] Verify Astro build (`cd site && npm install && npm run build`)
 
-## Phase 6: Cloudflare Worker
+## Phase 6: Cloudflare Hosting
 
-- [x] Write labs-proxy.js reverse proxy Worker
-- [x] Write wrangler.toml configuration
-- [ ] Deploy Worker and configure route (requires Cloudflare credentials)
+- [x] Create Cloudflare Pages project (yo-yodyne-labs)
+- [x] Add CNAME record: labs → yo-yodyne-labs.pages.dev
+- [x] Add labs.yo-yodyne.com as custom domain on Pages project
+- [x] Verify site at labs.yo-yodyne.com
 
 ## Phase 7: CI/CD
 
@@ -114,7 +115,9 @@
 - [x] Download and place web fonts in site/public/fonts/
 - [x] Set up git remote
 - [x] Initial commit and push to labs-init branch
-- [ ] Set up Cloudflare Pages project (PI — see engineering/guides/cloudflare-setup.md)
-- [ ] Deploy Cloudflare Worker (PI)
-- [ ] Configure DNS (PI — switch A records to proxied, add Worker route)
+- [x] Set up Cloudflare Pages project
+- [x] Configure DNS (CNAME labs → yo-yodyne-labs.pages.dev)
+- [x] Pivot from /labs subpath to labs.yo-yodyne.com subdomain
+- [x] Deploy site to labs.yo-yodyne.com
+- [x] Update specs and docs to reflect subdomain architecture
 - [ ] Push to main and tag v0.1.0-alpha.1

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -10,7 +10,7 @@ The project orchestrates research, engineering, and creative production through 
 
 - **Name:** Neilson P. Eney
 - **Domain:** yo-yodyne.com (Adobe Portfolio — photography/portfolio)
-- **Labs Site:** yo-yodyne.com/labs (Cloudflare Worker → Cloudflare Pages — research hub)
+- **Labs Site:** labs.yo-yodyne.com (Cloudflare Pages — research hub)
 - **GitHub:** github.com/neilsone
 - **Primary Repo:** github.com/neilsone/yo-yodyne
 - **Project Subdomains:** `*.yo-yodyne.com` for individual projects/programs
@@ -20,7 +20,7 @@ The project orchestrates research, engineering, and creative production through 
 | Layer | Technology | Version |
 |---|---|---|
 | Static Site Generator | Astro | latest |
-| Hosting (labs) | Cloudflare Pages + Worker reverse proxy | — |
+| Hosting (labs) | Cloudflare Pages | — |
 | DNS / CDN | Cloudflare | — |
 | CI/CD | GitHub Actions | — |
 | Spec Framework | OpenSpec (OPSX) | latest |
@@ -33,13 +33,13 @@ The project orchestrates research, engineering, and creative production through 
 
 ```
 yo-yodyne.com                     Adobe Portfolio (photography/portfolio)
-yo-yodyne.com/labs/*              Cloudflare Worker → yo-yodyne-labs.pages.dev (Astro)
+labs.yo-yodyne.com                Cloudflare Pages → yo-yodyne-labs.pages.dev (Astro)
 *.yo-yodyne.com                   Project subdomains (independent repos)
 
 yo-yodyne/                        This repo — orchestration hub
 ├── openspec/                     Spec-driven development (source of truth)
 ├── .claude/teams/                Agent team definitions
-├── site/                         Astro static site (yo-yodyne.com/labs)
+├── site/                         Astro static site (labs.yo-yodyne.com)
 ├── research/                     Research artifacts
 ├── engineering/                  Engineering standards, templates, tooling
 ├── production/                   Creative production, briefs, multimedia
@@ -78,5 +78,5 @@ yo-yodyne/                        This repo — orchestration hub
 | Artifact | Any deliverable: paper, spec, code, site content, media |
 | Creative Brief | Production-initiated task that can drive work across units |
 | PI | Principal Investigator — Neilson Eney |
-| Labs | The public-facing research hub site at yo-yodyne.com/labs |
+| Labs | The public-facing research hub site at labs.yo-yodyne.com |
 | RRR | Release Readiness Review — gating checklist for releases |

--- a/openspec/specs/site/spec.md
+++ b/openspec/specs/site/spec.md
@@ -10,15 +10,15 @@
 #### Scenario: URL Structure
 - GIVEN the Yo-Yodyne web presence
 - WHEN users access the labs site
-- THEN it SHALL be served at `yo-yodyne.com/labs/`
+- THEN it SHALL be served at `labs.yo-yodyne.com`
 - AND subfolder organization SHALL be used for content sections
 - AND individual projects SHALL be deployed as subdomains (`project.yo-yodyne.com`)
 
-#### Scenario: Reverse Proxy
-- GIVEN requests to `yo-yodyne.com/labs/*`
-- WHEN the Cloudflare Worker intercepts them
-- THEN it SHALL proxy to the Cloudflare Pages deployment
-- AND all other requests SHALL pass through to Adobe Portfolio
+#### Scenario: Subdomain Hosting
+- GIVEN the labs site deployment
+- WHEN it is hosted on Cloudflare Pages
+- THEN it SHALL be served via CNAME record pointing to `yo-yodyne-labs.pages.dev`
+- AND the main domain `yo-yodyne.com` SHALL remain on Adobe Portfolio
 
 ## Requirement: Technology
 


### PR DESCRIPTION
…ture

Migrate all references from yo-yodyne.com/labs subpath to labs.yo-yodyne.com subdomain. Update site spec, proposal, design doc, setup guide, project context, README, CHANGELOG, and CLAUDE.md. Remove Worker reverse proxy references from architecture docs.